### PR TITLE
Use env(1) to find path to bash

### DIFF
--- a/osget
+++ b/osget
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 #uncomment for debugging
 #set -x


### PR DESCRIPTION
Makes the script work on systems that don't have bash installed at /bin/bash,
like most BSD systems and NixOS.