### PR TITLE
Check hashes in order from stronger to weaker, drop support for SHA1

### DIFF
--- a/etc/osget/oslist/Archlinux/archlinux-2021.08.01
+++ b/etc/osget/oslist/Archlinux/archlinux-2021.08.01
@@ -3,4 +3,4 @@
 # Urls for Arch via http
 URL1="https://mirror.rackspace.com/archlinux/iso/2021.08.01/archlinux-2021.08.01-x86_64.iso"
 MAGNET="magnet:?xt=urn:btih:53a9a99871a7beab25fc1b9d83713d696613aa65&dn=archlinux-2021.08.01-x86_64.iso"
-SHA1SUM="4904c8a6df8bac8291b7b7582c26c4da9439f1cf"
+SHA256SUM="601560a815c191a44485743b1636de7ff7ecd09937ad65bfe6ad15248f10dd30"

--- a/osget
+++ b/osget
@@ -137,22 +137,18 @@ verify_file () {
 	file=${URL##*/}
 
 	if [ "$DOWNLOAD_DIR" = "" ];then	
-		if [ "$SHA1SUM" = "$(sha1sum $file|awk '{print $1}')" ];then
+		if [ "$SHA512SUM" = "$(sha1sum $file|awk '{print $1}')" ];then
 			echo "Checksum of downloaded file matches."
 		elif [ "$SHA256SUM" = "$(sha256sum $file|awk '{print $1}')" ];then
-			echo "Checksum of downloaded file matches."
-		elif [ "$SHA512SUM" = "$(sha512sum $file|awk '{print $1}')" ];then
 			echo "Checksum of downloaded file matches."
 		else
 			echo "WARNING: This file could be a fake!" 
 			echo "Checksum of downloaded file does NOT match the checksum on record!"
 		fi
 	else
-		if [ "$SHA1SUM" = "$(sha1sum $DOWNLOAD_DIR/$file|awk '{print $1}')" ];then
+		if [ "$SHA512SUM" = "$(sha1sum $DOWNLOAD_DIR/$file|awk '{print $1}')" ];then
 			echo "Checksum of downloaded file matches."
 		elif [ "$SHA256SUM" = "$(sha256sum $DOWNLOAD_DIR/$file|awk '{print $1}')" ];then
-			echo "Checksum of downloaded file matches."
-		elif [ "$SHA512SUM" = "$(sha512sum "$DOWNLOAD_DIR"/"$file"|awk '{print $1}')" ];then
 			echo "Checksum of downloaded file matches."
 		else
 			echo "WARNING: This file could be a fake!" 


### PR DESCRIPTION
SHA1 is old and crufty, and should be retired. Remove support and drop
SHA1SUM line from the only distro config file that contains one.

Also modify the order of hash comparisons to always check the strongest
hash.