### PR TITLE
Allow overriding CONFIGURATION_DIR through environment variable

### DIFF
--- a/osget
+++ b/osget
@@ -5,7 +5,11 @@
 
 #always use an absolute path for configuration directory
 #if you use a relative path you can only run osget from the directory the script is in.
-readonly CONFIGURATION_DIR="/etc/osget"
+if [ -z "$OSDEV_CONFIGURATION_DIR"  ]; then
+	readonly CONFIGURATION_DIR="/etc/osget"
+else
+	readonly CONFIGURATION_DIR="$OSDEV_CONFIGURATION_DIR"
+fi
 VERSION="1.2"
 
 # shellcheck source=/etc/osget/osget.conf


### PR DESCRIPTION
Use $OSDEV_CONFIGURATION_DIR environment variable for the configuration
directory if specified, otherwise default to /etc/osget.

Makes it easier to use the script without installing using e.g.:
OSDEV_CONFIGURATION_DIR=~/osget/etc/osget ~/osget/osget Ubuntu