### PR TITLE
Fix SHA512 check (broken during last commit)

### DIFF
--- a/osget
+++ b/osget
@@ -137,7 +137,7 @@ verify_file () {
 	file=${URL##*/}
 
 	if [ "$DOWNLOAD_DIR" = "" ];then	
-		if [ "$SHA512SUM" = "$(sha1sum $file|awk '{print $1}')" ];then
+		if [ "$SHA512SUM" = "$(sha512sum $file|awk '{print $1}')" ];then
 			echo "Checksum of downloaded file matches."
 		elif [ "$SHA256SUM" = "$(sha256sum $file|awk '{print $1}')" ];then
 			echo "Checksum of downloaded file matches."
@@ -146,7 +146,7 @@ verify_file () {
 			echo "Checksum of downloaded file does NOT match the checksum on record!"
 		fi
 	else
-		if [ "$SHA512SUM" = "$(sha1sum $DOWNLOAD_DIR/$file|awk '{print $1}')" ];then
+		if [ "$SHA512SUM" = "$(sha512sum $DOWNLOAD_DIR/$file|awk '{print $1}')" ];then
 			echo "Checksum of downloaded file matches."
 		elif [ "$SHA256SUM" = "$(sha256sum $DOWNLOAD_DIR/$file|awk '{print $1}')" ];then
 			echo "Checksum of downloaded file matches."


### PR DESCRIPTION
My commit earlier this morning (5b3fc452247124ac16fb24f64f86dbf83730e2e2)
broke SHA512 checking. It's checking the defined SHA512 hash with the
file's SHA1 hash, which will of course never match.

Luckily this is not a security issue as it can only ever result in a valid
file being rejected, not the other way around.

Fix the check to actually compare against the file's SHA512 checksum.
